### PR TITLE
Feat/#3 회원가입 로그인 및 회원 관련 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,8 +39,12 @@ dependencies {
     // JPA
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 
+    //Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
     // MySQL
     runtimeOnly 'com.mysql:mysql-connector-j'
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,11 @@ dependencies {
     // MySQL
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/project/team5backend/Team4BackEndApplication.java
+++ b/src/main/java/com/project/team5backend/Team4BackEndApplication.java
@@ -2,8 +2,13 @@ package com.project.team5backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
+@EntityScan(basePackages = "package com.project.team5backend.domain.user.entity")
+
 public class Team4BackEndApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/project/team5backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/project/team5backend/domain/auth/controller/AuthController.java
@@ -1,7 +1,6 @@
 package com.project.team5backend.domain.auth.controller;
 
 
-
 import com.project.team5backend.domain.auth.service.command.AuthCommandService;
 import com.project.team5backend.domain.user.dto.request.UserRequest;
 import com.project.team5backend.domain.user.dto.response.UserResponse;
@@ -11,12 +10,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
 public class AuthController {
 
     private final AuthCommandService authCommandService;
+
 
     @Operation(summary = "회원가입", description = "이메일과 비밀번호로 회원가입")
     @PostMapping("/signup")
@@ -34,17 +35,9 @@ public class AuthController {
         return ResponseEntity.ok(
                 new UserResponse.CommonResponse("success", "로그인이 완료되었습니다.", result)
         );
+
     }
 
-    @Operation(summary = "카카오 로그인", description = "카카오 인가 코드를 받아 소셜 로그인")
-    @GetMapping("/kakao/callback")
-    public ResponseEntity<UserResponse.CommonResponse> kakaoLogin(@RequestParam String code,
-                                                                  HttpServletResponse response) {
-        UserResponse.LoginResult result = authCommandService.kakaoLogin(code, response);
-        return ResponseEntity.ok(
-                new UserResponse.CommonResponse("success", "카카오 로그인이 완료되었습니다.", result)
-        );
-    }
     @Operation(summary = "이메일 인증코드 전송", description = "이메일로 인증코드 전송")
     @PostMapping("/send-code")
     public ResponseEntity<UserResponse.CommonResponse> sendVerificationCode(@RequestParam String email) {

--- a/src/main/java/com/project/team5backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/project/team5backend/domain/auth/controller/AuthController.java
@@ -4,56 +4,47 @@ package com.project.team5backend.domain.auth.controller;
 import com.project.team5backend.domain.auth.service.command.AuthCommandService;
 import com.project.team5backend.domain.user.dto.request.UserRequest;
 import com.project.team5backend.domain.user.dto.response.UserResponse;
+import com.project.team5backend.global.apiPayload.CustomResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 
 @RestController
-@RequestMapping("/api/auth")
+@RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
 public class AuthController {
 
     private final AuthCommandService authCommandService;
 
-
     @Operation(summary = "회원가입", description = "이메일과 비밀번호로 회원가입")
     @PostMapping("/signup")
-    public ResponseEntity<UserResponse.CommonResponse> signUp(@RequestBody UserRequest.SignUp request) {
+    public CustomResponse<String> signUp(@RequestBody UserRequest.SignUp request) {
         authCommandService.signUp(request);
-        return ResponseEntity.ok(new UserResponse.CommonResponse("success", "회원가입이 완료되었습니다.", null));
+        return CustomResponse.onSuccess("회원가입을 성공했습니다.");
     }
-
 
     @Operation(summary = "일반 로그인", description = "이메일과 비밀번호으로 로그인")
     @PostMapping("/login")
-    public ResponseEntity<UserResponse.CommonResponse> login(@RequestBody UserRequest.Login request,
+    public CustomResponse<UserResponse.LoginResult> login(@RequestBody UserRequest.Login request,
                                                              HttpServletResponse response) {
         UserResponse.LoginResult result = authCommandService.login(request, response);
-        return ResponseEntity.ok(
-                new UserResponse.CommonResponse("success", "로그인이 완료되었습니다.", result)
-        );
-
+        return CustomResponse.onSuccess(result);
     }
 
     @Operation(summary = "이메일 인증코드 전송", description = "이메일로 인증코드 전송")
     @PostMapping("/send-code")
-    public ResponseEntity<UserResponse.CommonResponse> sendVerificationCode(@RequestParam String email) {
+    public CustomResponse<String> sendVerificationCode(@RequestParam String email) {
         authCommandService.sendVerificationCode(email);
-        return ResponseEntity.ok(
-                new UserResponse.CommonResponse("success", "이메일 인증 코드가 전송되었습니다.", null)
-        );
+        return CustomResponse.onSuccess("이메일 인증 코드를 전송했습니다.");
     }
 
     @Operation(summary = "이메일 인증코드 검증", description = "인증코드 유효성 검증")
     @PostMapping("/verify-code")
-    public ResponseEntity<UserResponse.CommonResponse> verifyCode(@RequestParam String email,
+    public CustomResponse<Boolean> verifyCode(@RequestParam String email,
                                                                   @RequestParam String code) {
         boolean result = authCommandService.verifyCode(email, code);
-        return ResponseEntity.ok(
-                new UserResponse.CommonResponse("success", "이메일 인증이 완료되었습니다.", result)
-        );
+        return CustomResponse.onSuccess(result);
     }
 }

--- a/src/main/java/com/project/team5backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/project/team5backend/domain/auth/controller/AuthController.java
@@ -1,4 +1,66 @@
 package com.project.team5backend.domain.auth.controller;
 
+
+
+import com.project.team5backend.domain.auth.service.command.AuthCommandService;
+import com.project.team5backend.domain.user.dto.request.UserRequest;
+import com.project.team5backend.domain.user.dto.response.UserResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
 public class AuthController {
+
+    private final AuthCommandService authCommandService;
+
+    @Operation(summary = "회원가입", description = "이메일과 비밀번호로 회원가입")
+    @PostMapping("/signup")
+    public ResponseEntity<UserResponse.CommonResponse> signUp(@RequestBody UserRequest.SignUp request) {
+        authCommandService.signUp(request);
+        return ResponseEntity.ok(new UserResponse.CommonResponse("success", "회원가입이 완료되었습니다.", null));
+    }
+
+
+    @Operation(summary = "일반 로그인", description = "이메일과 비밀번호으로 로그인")
+    @PostMapping("/login")
+    public ResponseEntity<UserResponse.CommonResponse> login(@RequestBody UserRequest.Login request,
+                                                             HttpServletResponse response) {
+        UserResponse.LoginResult result = authCommandService.login(request, response);
+        return ResponseEntity.ok(
+                new UserResponse.CommonResponse("success", "로그인이 완료되었습니다.", result)
+        );
+    }
+
+    @Operation(summary = "카카오 로그인", description = "카카오 인가 코드를 받아 소셜 로그인")
+    @GetMapping("/kakao/callback")
+    public ResponseEntity<UserResponse.CommonResponse> kakaoLogin(@RequestParam String code,
+                                                                  HttpServletResponse response) {
+        UserResponse.LoginResult result = authCommandService.kakaoLogin(code, response);
+        return ResponseEntity.ok(
+                new UserResponse.CommonResponse("success", "카카오 로그인이 완료되었습니다.", result)
+        );
+    }
+    @Operation(summary = "이메일 인증코드 전송", description = "이메일로 인증코드 전송")
+    @PostMapping("/send-code")
+    public ResponseEntity<UserResponse.CommonResponse> sendVerificationCode(@RequestParam String email) {
+        authCommandService.sendVerificationCode(email);
+        return ResponseEntity.ok(
+                new UserResponse.CommonResponse("success", "이메일 인증 코드가 전송되었습니다.", null)
+        );
+    }
+
+    @Operation(summary = "이메일 인증코드 검증", description = "인증코드 유효성 검증")
+    @PostMapping("/verify-code")
+    public ResponseEntity<UserResponse.CommonResponse> verifyCode(@RequestParam String email,
+                                                                  @RequestParam String code) {
+        boolean result = authCommandService.verifyCode(email, code);
+        return ResponseEntity.ok(
+                new UserResponse.CommonResponse("success", "이메일 인증이 완료되었습니다.", result)
+        );
+    }
 }

--- a/src/main/java/com/project/team5backend/domain/auth/service/command/AuthCommandService.java
+++ b/src/main/java/com/project/team5backend/domain/auth/service/command/AuthCommandService.java
@@ -9,8 +9,6 @@ public interface AuthCommandService {
     void signUp(UserRequest.SignUp request);
     UserResponse.LoginResult login(UserRequest.Login request, HttpServletResponse response);
 
-    UserResponse.LoginResult kakaoLogin(String code, HttpServletResponse response);
-
     // 이메일 인증
     void sendVerificationCode(String email);
     boolean verifyCode(String email, String code);

--- a/src/main/java/com/project/team5backend/domain/auth/service/command/AuthCommandService.java
+++ b/src/main/java/com/project/team5backend/domain/auth/service/command/AuthCommandService.java
@@ -1,4 +1,17 @@
 package com.project.team5backend.domain.auth.service.command;
 
+
+import com.project.team5backend.domain.user.dto.request.UserRequest;
+import com.project.team5backend.domain.user.dto.response.UserResponse;
+import jakarta.servlet.http.HttpServletResponse;
+
 public interface AuthCommandService {
+    void signUp(UserRequest.SignUp request);
+    UserResponse.LoginResult login(UserRequest.Login request, HttpServletResponse response);
+
+    UserResponse.LoginResult kakaoLogin(String code, HttpServletResponse response);
+
+    // 이메일 인증
+    void sendVerificationCode(String email);
+    boolean verifyCode(String email, String code);
 }

--- a/src/main/java/com/project/team5backend/domain/auth/service/command/AuthCommandServiceImpl.java
+++ b/src/main/java/com/project/team5backend/domain/auth/service/command/AuthCommandServiceImpl.java
@@ -1,4 +1,153 @@
 package com.project.team5backend.domain.auth.service.command;
 
-public class AuthCommandServiceImpl {
+
+import com.project.team5backend.domain.user.dto.request.UserRequest;
+import com.project.team5backend.domain.user.dto.response.UserResponse;
+import com.project.team5backend.domain.user.entity.User;
+import com.project.team5backend.domain.user.repository.UserRepository;
+import com.project.team5backend.global.util.CookieUtil;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+@RequiredArgsConstructor
+public class AuthCommandServiceImpl implements AuthCommandService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    private final Map<String, String> codeStore = new ConcurrentHashMap<>();
+
+
+    @Value("${kakao.rest-api-key}")
+    private String kakaoRestApiKey;
+
+    @Value("${kakao.redirect-uri}")
+    private String kakaoRedirectUri;
+
+    @Override
+    public void sendVerificationCode(String email) {
+        String code = UUID.randomUUID().toString().substring(0, 6);
+        codeStore.put(email, code);
+        // TODO: 실제 이메일 전송 로직 넣기
+        System.out.println("[이메일 전송] " + email + " : 인증 코드 = " + code);
+    }
+
+    @Override
+    @Transactional
+    public boolean verifyCode(String email, String code) {
+        boolean isValid = code.equals(codeStore.get(email));
+        if (isValid) {
+            User user = userRepository.findByEmailAndIsDeletedFalse(email)
+                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다."));
+            user.setEmailVerified(true);
+        }
+        return isValid;
+    }
+
+    @Override
+    public void signUp(UserRequest.SignUp request) {
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
+        }
+
+        User user = User.builder()
+                .email(request.getEmail())
+                .name(request.getName())
+                .password(passwordEncoder.encode(request.getPassword()))
+                .build();
+
+        userRepository.save(user);
+    }
+
+    @Override
+    public UserResponse.LoginResult login(UserRequest.Login request, HttpServletResponse response) {
+        User user = userRepository.findByEmailAndIsDeletedFalse(request.getEmail())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다."));
+        // 개발 완료되면 뺴도 됨
+        System.out.println("✅ user = " + user);
+        System.out.println("✅ id = " + user.getId());
+        System.out.println("✅ name = " + user.getName());
+        System.out.println("✅ email = " + user.getEmail());
+
+        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        String sessionId = UUID.randomUUID().toString();
+
+        ResponseCookie cookie = ResponseCookie.from("SESSION", sessionId)
+                .httpOnly(true)
+                .secure(false) // 배포 시 true로 변경
+                .path("/")
+                .sameSite("Lax")
+                .maxAge(Duration.ofDays(7))
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
+        return new UserResponse.LoginResult(user.getId(), user.getName(), user.getEmail());
+
+    }
+
+    @Override
+    public UserResponse.LoginResult kakaoLogin(String code, HttpServletResponse response) {
+        String tokenUri = "https://kauth.kakao.com/oauth/token";
+        String userInfoUri = "https://kapi.kakao.com/v2/user/me";
+
+        RestTemplate restTemplate = new RestTemplate();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", kakaoRestApiKey);
+        body.add("redirect_uri", kakaoRedirectUri);
+        body.add("code", code);
+
+        HttpEntity<MultiValueMap<String, String>> tokenRequest = new HttpEntity<>(body, headers);
+        ResponseEntity<Map> tokenResponse = restTemplate.postForEntity(tokenUri, tokenRequest, Map.class);
+        String accessToken = (String) tokenResponse.getBody().get("access_token");
+
+        HttpHeaders userInfoHeaders = new HttpHeaders();
+        userInfoHeaders.setBearerAuth(accessToken);
+        HttpEntity<Void> userInfoRequest = new HttpEntity<>(userInfoHeaders);
+
+        ResponseEntity<Map> userInfoResponse = restTemplate.exchange(
+                userInfoUri, HttpMethod.GET, userInfoRequest, Map.class);
+
+        Map<String, Object> kakaoAccount = (Map<String, Object>) userInfoResponse.getBody().get("kakao_account");
+        Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+
+        String email = (String) kakaoAccount.get("email");
+        String nickname = (String) profile.get("nickname");
+
+        User user = userRepository.findByEmailAndIsDeletedFalse(email)
+                .orElseGet(() -> {
+                    User newUser = User.builder()
+                            .email(email)
+                            .name(nickname)
+                            .password(passwordEncoder.encode(UUID.randomUUID().toString()))
+                            .isEmailVerified(true)
+                            .build();
+                    return userRepository.save(newUser);
+                });
+
+        CookieUtil.addCookie(response, "USER_ID", String.valueOf(user.getId()), 60 * 60 * 24);
+        return new UserResponse.LoginResult(user.getId(), user.getName(), user.getEmail());
+    }
 }

--- a/src/main/java/com/project/team5backend/domain/auth/service/command/AuthCommandServiceImpl.java
+++ b/src/main/java/com/project/team5backend/domain/auth/service/command/AuthCommandServiceImpl.java
@@ -5,87 +5,120 @@ import com.project.team5backend.domain.user.dto.request.UserRequest;
 import com.project.team5backend.domain.user.dto.response.UserResponse;
 import com.project.team5backend.domain.user.entity.User;
 import com.project.team5backend.domain.user.repository.UserRepository;
-import com.project.team5backend.global.util.CookieUtil;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.*;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.RestTemplate;
+
 
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class AuthCommandServiceImpl implements AuthCommandService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final Map<String, User> sessionStore;
+    private final JavaMailSender mailSender;
 
 
-    private final Map<String, String> codeStore = new ConcurrentHashMap<>();
+    private final  RedisTemplate<String, String> redisTemplate;
+
+    private static final Duration CODE_EXPIRATION_TIME = Duration.ofMinutes(5);
+
+    private static final String VERIFIED_EMAIL_PREFIX = "verified:";
+    // 인증 완료 상태 만료 시간
+    private static final Duration VERIFIED_EMAIL_EXPIRATION_TIME = Duration.ofMinutes(10);
 
 
-    @Override
-    public void sendVerificationCode(String email) {
-        String code = UUID.randomUUID().toString().substring(0, 6);
-        codeStore.put(email, code);
-        System.out.println("[이메일 전송] " + email + " : 인증 코드 = " + code);
+    private String generateCode() {
+        Random random = new Random();
+        int code = 100000 + random.nextInt(900000);
+        return String.valueOf(code);
     }
 
     @Override
-    @Transactional
+    public void sendVerificationCode(String email) {
+        String code = generateCode();
+        redisTemplate.opsForValue().set(email, code, CODE_EXPIRATION_TIME);
+        System.out.println("[이메일 전송] " + email + " : 인증 코드 = " + code);
+        //  실제 이메일 전송 로직 구현
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(email);
+        message.setSubject("회원가입 인증 코드입니다.");
+        message.setText("인증 코드는 " + code + " 입니다.");
+        mailSender.send(message);
+    }
+    @Override
     public boolean verifyCode(String email, String code) {
-        boolean isValid = code.equals(codeStore.get(email));
+        String storedCode = redisTemplate.opsForValue().get(email);
+        boolean isValid = code.equals(storedCode);
+
         if (isValid) {
-            User user = userRepository.findByEmailAndIsDeletedFalse(email)
-                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다."));
-            user.setEmailVerified(true);
+            // 1. 인증 성공 시, Redis에서 인증 코드 삭제
+            redisTemplate.delete(email);
+
+            // 2. Redis에 이메일 인증 완료 상태 저장
+            redisTemplate.opsForValue().set(VERIFIED_EMAIL_PREFIX + email, "true", VERIFIED_EMAIL_EXPIRATION_TIME);
+
+            // 3. 사용자 이메일 인증 상태 업데이트 (선택적)
+            // user.verifyEmail();
         }
         return isValid;
     }
     @Override
     public void signUp(UserRequest.SignUp request) {
-        if (userRepository.existsByEmail(request.getEmail())) {
+        String verifiedStatus = redisTemplate.opsForValue().get(VERIFIED_EMAIL_PREFIX + request.email());
+
+        // Redis에서 이메일 인증 완료 상태 확인
+        if (verifiedStatus == null || !verifiedStatus.equals("true")) {
+            throw new IllegalArgumentException("이메일 인증이 완료되지 않았습니다.");
+        }
+        if (userRepository.existsByEmail(request.email())) {
             throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
         }
+        // 인증 완료 후 Redis에서 상태 삭제
+        redisTemplate.delete(VERIFIED_EMAIL_PREFIX + request.email());
 
+        // User 엔티티 생성 및 저장
         User user = User.builder()
-                .email(request.getEmail())
-                .name(request.getName())
-                .password(passwordEncoder.encode(request.getPassword()))
+                .email(request.email())
+                .name(request.name())
+                .password(passwordEncoder.encode(request.password()))
+                .isEmailVerified(true)
                 .build();
 
         userRepository.save(user);
     }
 
+
     @Override
     public UserResponse.LoginResult login(UserRequest.Login request, HttpServletResponse response) {
-        User user = userRepository.findByEmailAndIsDeletedFalse(request.getEmail())
+        User user = userRepository.findByEmailAndIsDeletedFalse(request.email())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다."));
 
-        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+        if (!passwordEncoder.matches(request.password(), user.getPassword())) {
             throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
         }
-
         String sessionId = UUID.randomUUID().toString();
         sessionStore.put(sessionId, user);
 
         System.out.println("[로그인 성공] SESSION ID: " + sessionId + ", USER ID: " + user.getId() + "가 세션에 저장되었습니다.");
-        System.out.println("[세션스토어 현재 상태] 크기: " + sessionStore.size() + ", 내용: " + sessionStore);
-
 
         ResponseCookie cookie = ResponseCookie.from("SESSION", sessionId)
                 .httpOnly(true)
@@ -94,9 +127,7 @@ public class AuthCommandServiceImpl implements AuthCommandService {
                 .sameSite("Lax")
                 .maxAge(Duration.ofDays(7))
                 .build();
-
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
-
         // 로그인 성공 후
         UsernamePasswordAuthenticationToken authentication =
                 new UsernamePasswordAuthenticationToken(
@@ -104,6 +135,5 @@ public class AuthCommandServiceImpl implements AuthCommandService {
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
         return new UserResponse.LoginResult(user.getId(), user.getName(), user.getEmail());
-
     }
 }

--- a/src/main/java/com/project/team5backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/project/team5backend/domain/user/controller/UserController.java
@@ -1,0 +1,70 @@
+package com.project.team5backend.domain.user.controller;
+
+
+import com.project.team5backend.domain.user.dto.response.UserResponse;
+import com.project.team5backend.domain.user.service.command.UserCommandService;
+import com.project.team5backend.domain.user.service.query.UserQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserQueryService queryService;
+    private final UserCommandService commandService;
+
+    private Long getUserIdFromCookie(HttpServletRequest request) {
+        for (Cookie cookie : request.getCookies()) {
+            if (cookie.getName().equals("USER_ID")) {
+                return Long.parseLong(cookie.getValue());
+            }
+        }
+        throw new IllegalArgumentException("인증 쿠키가 없습니다.");
+    }
+
+    @Operation(summary = "회원정보 조회", description = "마이페이지에서 정보 조회")
+    @GetMapping("/me")
+    public UserResponse.MyInfo getMyInfo(HttpServletRequest request) {
+        Long userId = getUserIdFromCookie(request);
+        return queryService.getMyInfo(userId);
+    }
+
+    @Operation(summary = "회원정보 수정", description = "회원 이름 수정")
+    @PatchMapping("/name")
+    public void updateName(HttpServletRequest request, @RequestParam String name) {
+        Long userId = getUserIdFromCookie(request);
+        commandService.updateName(userId, name);
+    }
+
+    @Operation(summary = "비밀번호 변경", description = "비밀번호 변경")
+    @PatchMapping("/password")
+    public void updatePassword(HttpServletRequest request,
+                               @RequestParam String currentPassword,
+                               @RequestParam String newPassword) {
+        Long userId = getUserIdFromCookie(request);
+        commandService.changePassword(userId, currentPassword, newPassword);
+    }
+
+    @Operation(summary = "회원 탈퇴", description = "계정 탈퇴")
+    @DeleteMapping("/logout")
+    public ResponseEntity<?> logout(HttpServletResponse response) {
+        ResponseCookie deleteCookie = ResponseCookie.from("SESSION", null)
+                .path("/")
+                .maxAge(0)
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, deleteCookie.toString());
+
+        return ResponseEntity.ok("로그아웃 완료");
+    }
+
+}

--- a/src/main/java/com/project/team5backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/project/team5backend/domain/user/controller/UserController.java
@@ -2,6 +2,7 @@ package com.project.team5backend.domain.user.controller;
 
 
 import com.project.team5backend.domain.user.dto.response.UserResponse;
+import com.project.team5backend.domain.user.entity.User;
 import com.project.team5backend.domain.user.service.command.UserCommandService;
 import com.project.team5backend.domain.user.service.query.UserQueryService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,10 +10,13 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/users")
@@ -21,50 +25,81 @@ public class UserController {
 
     private final UserQueryService queryService;
     private final UserCommandService commandService;
+    @Autowired
+    private Map<String, User> sessionStore;
 
     private Long getUserIdFromCookie(HttpServletRequest request) {
-        for (Cookie cookie : request.getCookies()) {
-            if (cookie.getName().equals("USER_ID")) {
-                return Long.parseLong(cookie.getValue());
+        Cookie[] cookies = request.getCookies();
+        //쿠키 배열이 null인지 확인
+        if (cookies == null) {
+            System.out.println("[쿠키 로그] 요청에 쿠키가 없습니다.");
+            throw new IllegalArgumentException("인증 쿠키가 없습니다.");
+        }
+
+        //쿠키를 순회하며 "SESSION" 쿠키를 찾는 로그
+        for (Cookie cookie : cookies) {
+            System.out.println("[쿠키 로그] 찾은 쿠키: " + cookie.getName() + " = " + cookie.getValue());
+            if ("SESSION".equals(cookie.getName())) {
+                String sessionId = cookie.getValue();
+                User user = sessionStore.get(sessionId);
+
+                // 세션 저장소에서 사용자를 찾았는지 확인하는 로그
+                if (user != null) {
+                    System.out.println("[세션 로그] SESSION ID로 사용자 찾기 성공! USER ID: " + user.getId());
+                    return user.getId();
+                } else {
+                    System.out.println("[세션 로그] SESSION ID(" + sessionId + ")에 해당하는 사용자가 세션 저장소에 없습니다.");
+                    throw new IllegalArgumentException("인증 쿠키가 유효하지 않습니다.");
+                }
             }
         }
+
+        // "SESSION" 쿠키를 찾지 못한 경우의 로그
+        System.out.println("[쿠키 로그] 'SESSION' 이름의 쿠키를 찾지 못했습니다.");
         throw new IllegalArgumentException("인증 쿠키가 없습니다.");
     }
 
     @Operation(summary = "회원정보 조회", description = "마이페이지에서 정보 조회")
     @GetMapping("/me")
-    public UserResponse.MyInfo getMyInfo(HttpServletRequest request) {
+    public ResponseEntity<UserResponse.CommonResponse> getMyInfo(HttpServletRequest request) {
         Long userId = getUserIdFromCookie(request);
-        return queryService.getMyInfo(userId);
+        UserResponse.MyInfo result = queryService.getMyInfo(userId);
+        return ResponseEntity.ok(new UserResponse.CommonResponse("success", "회원 정보 조회 성공", result));
     }
 
     @Operation(summary = "회원정보 수정", description = "회원 이름 수정")
     @PatchMapping("/name")
-    public void updateName(HttpServletRequest request, @RequestParam String name) {
+    public ResponseEntity<UserResponse.CommonResponse> updateName(HttpServletRequest request, @RequestParam String name) {
         Long userId = getUserIdFromCookie(request);
         commandService.updateName(userId, name);
+        return ResponseEntity.ok(new UserResponse.CommonResponse("success", "회원 이름 수정 완료", null));
     }
 
     @Operation(summary = "비밀번호 변경", description = "비밀번호 변경")
     @PatchMapping("/password")
-    public void updatePassword(HttpServletRequest request,
-                               @RequestParam String currentPassword,
-                               @RequestParam String newPassword) {
+    public ResponseEntity<UserResponse.CommonResponse> updatePassword(HttpServletRequest request,
+                                                                      @RequestParam String currentPassword,
+                                                                      @RequestParam String newPassword) {
         Long userId = getUserIdFromCookie(request);
         commandService.changePassword(userId, currentPassword, newPassword);
+        return ResponseEntity.ok(new UserResponse.CommonResponse("success", "비밀번호 변경 완료", null));
     }
 
     @Operation(summary = "회원 탈퇴", description = "계정 탈퇴")
-    @DeleteMapping("/logout")
-    public ResponseEntity<?> logout(HttpServletResponse response) {
-        ResponseCookie deleteCookie = ResponseCookie.from("SESSION", null)
+    @DeleteMapping("/delete")
+    public ResponseEntity<UserResponse.CommonResponse> deleteUser(HttpServletRequest request,
+                                                                  HttpServletResponse response) {
+        Long userId = getUserIdFromCookie(request);
+        commandService.deleteUser(userId); // 실제 사용자 삭제
+
+        // 쿠키 삭제
+        ResponseCookie deleteCookie = ResponseCookie.from("USER_ID", null)
                 .path("/")
                 .maxAge(0)
                 .build();
-
         response.addHeader(HttpHeaders.SET_COOKIE, deleteCookie.toString());
 
-        return ResponseEntity.ok("로그아웃 완료");
+        return ResponseEntity.ok(new UserResponse.CommonResponse("success", "회원 탈퇴 완료", null));
     }
 
 }

--- a/src/main/java/com/project/team5backend/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/project/team5backend/domain/user/converter/UserConverter.java
@@ -1,0 +1,35 @@
+package com.project.team5backend.domain.user.converter;
+
+import com.project.team5backend.domain.user.dto.request.UserRequest;
+import com.project.team5backend.domain.user.dto.response.UserResponse;
+import com.project.team5backend.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserConverter {
+
+    private final PasswordEncoder passwordEncoder;
+
+    // SignUp DTO를 User 엔티티로 변환
+    public User toUser(UserRequest.SignUp request) {
+        return User.builder()
+                .email(request.email())
+                .name(request.name())
+                .password(passwordEncoder.encode(request.password()))
+                .isEmailVerified(true) // 이메일 인증이 완료된 상태로 가정
+                .build();
+    }
+
+    // User 엔티티를 LoginResult DTO로 변환
+    public UserResponse.LoginResult toLoginResult(User user) {
+        return new UserResponse.LoginResult(user.getId(), user.getName(), user.getEmail());
+    }
+
+    // User 엔티티를 MyInfo DTO로 변환
+    public UserResponse.MyInfo toMyInfo(User user) {
+        return new UserResponse.MyInfo(user.getId(), user.getName(), user.getEmail(), user.getCreatedAt(), user.getUpdatedAt());
+    }
+}

--- a/src/main/java/com/project/team5backend/domain/user/dto/request/UserRequest.java
+++ b/src/main/java/com/project/team5backend/domain/user/dto/request/UserRequest.java
@@ -3,21 +3,18 @@ package com.project.team5backend.domain.user.dto.request;
 
 import lombok.*;
 
+@Getter @Setter
+@NoArgsConstructor
 public class UserRequest {
 
-    @Getter @Setter
-    @NoArgsConstructor
-    public static class SignUp {
-        private String email;
-        private String password;
-        private String name;
-    }
-
-    @Getter @Setter
-    @NoArgsConstructor
-    public static class Login {
-        private String email;
-        private String password;
-    }
+    public record Login(
+            String email,
+            String password
+    ) {}
+    public record SignUp(
+            String email,
+            String password,
+            String name
+    ) {}
 }
 

--- a/src/main/java/com/project/team5backend/domain/user/dto/request/UserRequest.java
+++ b/src/main/java/com/project/team5backend/domain/user/dto/request/UserRequest.java
@@ -1,0 +1,23 @@
+package com.project.team5backend.domain.user.dto.request;
+
+
+import lombok.*;
+
+public class UserRequest {
+
+    @Getter @Setter
+    @NoArgsConstructor
+    public static class SignUp {
+        private String email;
+        private String password;
+        private String name;
+    }
+
+    @Getter @Setter
+    @NoArgsConstructor
+    public static class Login {
+        private String email;
+        private String password;
+    }
+}
+

--- a/src/main/java/com/project/team5backend/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/com/project/team5backend/domain/user/dto/response/UserResponse.java
@@ -1,0 +1,30 @@
+package com.project.team5backend.domain.user.dto.response;
+
+import lombok.*;
+
+public class UserResponse {
+
+    @Getter @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class LoginResult {
+        private Long userId;
+        private String name;
+        private String email;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class MyInfo {
+        private String email;
+        private String name;
+    }
+    @Getter
+    @AllArgsConstructor
+    public static class CommonResponse {
+        private String status;
+        private String message;
+        private Object data;
+    }
+}
+

--- a/src/main/java/com/project/team5backend/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/com/project/team5backend/domain/user/dto/response/UserResponse.java
@@ -4,32 +4,24 @@ import lombok.*;
 
 import java.time.LocalDateTime;
 
+
+@Getter @Setter
+@AllArgsConstructor
 public class UserResponse {
 
-    @Getter @Setter
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class LoginResult {
-        private Long userId;
-        private String name;
-        private String email;
-    }
-
-    @Getter
-    @AllArgsConstructor
-    public static class MyInfo {
-        private Long userId;
-        private String name;
-        private String email;
-        private LocalDateTime createdAt;
-        private LocalDateTime updatedAt;
-    }
-    @Getter
-    @AllArgsConstructor
-    public static class CommonResponse {
-        private String status;
-        private String message;
-        private Object data;
-    }
+    public record LoginResult (
+            Long userId,
+            String name,
+            String email
+        ){}
+    public record MyInfo (
+            Long userId,
+            String name,
+            String email,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ){}
 }
+
+
 

--- a/src/main/java/com/project/team5backend/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/com/project/team5backend/domain/user/dto/response/UserResponse.java
@@ -2,6 +2,8 @@ package com.project.team5backend.domain.user.dto.response;
 
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 public class UserResponse {
 
     @Getter @Setter
@@ -16,8 +18,11 @@ public class UserResponse {
     @Getter
     @AllArgsConstructor
     public static class MyInfo {
-        private String email;
+        private Long userId;
         private String name;
+        private String email;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
     }
     @Getter
     @AllArgsConstructor

--- a/src/main/java/com/project/team5backend/domain/user/entity/User.java
+++ b/src/main/java/com/project/team5backend/domain/user/entity/User.java
@@ -1,4 +1,45 @@
 package com.project.team5backend.domain.user.entity;
 
-public class User {
+import com.project.team5backend.global.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class User extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(name = "is_deleted")
+    private boolean isDeleted = false;
+
+    @Column(name = "is_email_verified")
+    @Setter
+    private boolean isEmailVerified = false;
+
+    public void changeName(String name) {
+        this.name = name;
+    }
+
+    public void changePassword(String encodedPassword) {
+        this.password = encodedPassword;
+    }
+
+    public void delete() {
+        this.isDeleted = true;
+    }
 }

--- a/src/main/java/com/project/team5backend/domain/user/entity/User.java
+++ b/src/main/java/com/project/team5backend/domain/user/entity/User.java
@@ -28,8 +28,11 @@ public class User extends BaseEntity {
     private boolean isDeleted = false;
 
     @Column(name = "is_email_verified")
-    @Setter
     private boolean isEmailVerified = false;
+
+    public void verifyEmail() {
+        this.isEmailVerified = true;
+    }
 
     public void changeName(String name) {
         this.name = name;

--- a/src/main/java/com/project/team5backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/project/team5backend/domain/user/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.project.team5backend.domain.user.repository;
+
+
+import com.project.team5backend.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    boolean existsByEmail(String email);
+    Optional<User> findByEmailAndIsDeletedFalse(String email);
+}

--- a/src/main/java/com/project/team5backend/domain/user/service/command/UserCommandService.java
+++ b/src/main/java/com/project/team5backend/domain/user/service/command/UserCommandService.java
@@ -1,0 +1,7 @@
+package com.project.team5backend.domain.user.service.command;
+
+public interface UserCommandService {
+    void updateName(Long userId, String newName);
+    void changePassword(Long userId, String currentPassword, String newPassword);
+    void deleteUser(Long userId);
+}

--- a/src/main/java/com/project/team5backend/domain/user/service/command/UserCommandServiceImpl.java
+++ b/src/main/java/com/project/team5backend/domain/user/service/command/UserCommandServiceImpl.java
@@ -1,0 +1,39 @@
+package com.project.team5backend.domain.user.service.command;
+
+import com.project.team5backend.domain.user.entity.User;
+import com.project.team5backend.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserCommandServiceImpl implements UserCommandService {
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public void updateName(Long userId, String newName) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        user.changeName(newName);
+    }
+
+    @Override
+    public void changePassword(Long userId, String currentPassword, String newPassword) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        if (!passwordEncoder.matches(currentPassword, user.getPassword())) {
+            throw new IllegalArgumentException("현재 비밀번호가 일치하지 않습니다.");
+        }
+        user.changePassword(passwordEncoder.encode(newPassword));
+    }
+
+    @Override
+    public void deleteUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        user.delete();
+    }
+
+}

--- a/src/main/java/com/project/team5backend/domain/user/service/command/UserCommandServiceImpl.java
+++ b/src/main/java/com/project/team5backend/domain/user/service/command/UserCommandServiceImpl.java
@@ -6,17 +6,36 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.util.Map;
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 public class UserCommandServiceImpl implements UserCommandService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final Map<String, User> sessionStore;
+
+    // 세션 스토어에서 사용자를 찾아 최신 정보로 갱신하는 보조 메서드
+    private void updateSessionStore(User updatedUser) {
+        // userId에 해당하는 sessionId를 찾음
+        Optional<String> optionalSessionId = sessionStore.entrySet().stream()
+                .filter(entry -> entry.getValue().getId().equals(updatedUser.getId()))
+                .map(Map.Entry::getKey)
+                .findFirst();
+
+        // sessionId가 존재하면, 해당 키의 value(User 객체)를 최신 정보로 교체
+        optionalSessionId.ifPresent(sessionId -> sessionStore.put(sessionId, updatedUser));
+    }
 
     @Override
     public void updateName(Long userId, String newName) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
         user.changeName(newName);
+
+        User updatedUser = userRepository.save(user); // db 업데이트
+        updateSessionStore(updatedUser); // 세션 스토어 업데이트
     }
 
     @Override
@@ -27,13 +46,16 @@ public class UserCommandServiceImpl implements UserCommandService {
             throw new IllegalArgumentException("현재 비밀번호가 일치하지 않습니다.");
         }
         user.changePassword(passwordEncoder.encode(newPassword));
+
+        User updatedUser = userRepository.save(user); // db 업데이트
+        updateSessionStore(updatedUser); // 세션 스토어 업데이트
     }
 
     @Override
     public void deleteUser(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
-        user.delete();
+        userRepository.delete(user);
     }
 
 }

--- a/src/main/java/com/project/team5backend/domain/user/service/query/UserQueryService.java
+++ b/src/main/java/com/project/team5backend/domain/user/service/query/UserQueryService.java
@@ -1,0 +1,10 @@
+package com.project.team5backend.domain.user.service.query;
+
+
+import com.project.team5backend.domain.user.dto.response.UserResponse;
+
+public interface UserQueryService {
+    // 회원 정보 수정(이름)
+    UserResponse.MyInfo getMyInfo(Long userId);
+}
+

--- a/src/main/java/com/project/team5backend/domain/user/service/query/UserQueryServiceImpl.java
+++ b/src/main/java/com/project/team5backend/domain/user/service/query/UserQueryServiceImpl.java
@@ -16,7 +16,7 @@ public class UserQueryServiceImpl implements UserQueryService {
     public UserResponse.MyInfo getMyInfo(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
-        return new UserResponse.MyInfo(user.getEmail(), user.getName());
+        return new UserResponse.MyInfo(user.getId(),user.getName(),user.getEmail(),user.getCreatedAt(),user.getUpdatedAt());
     }
 }
 

--- a/src/main/java/com/project/team5backend/domain/user/service/query/UserQueryServiceImpl.java
+++ b/src/main/java/com/project/team5backend/domain/user/service/query/UserQueryServiceImpl.java
@@ -1,0 +1,22 @@
+package com.project.team5backend.domain.user.service.query;
+
+import com.project.team5backend.domain.user.dto.response.UserResponse;
+import com.project.team5backend.domain.user.entity.User;
+import com.project.team5backend.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserQueryServiceImpl implements UserQueryService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserResponse.MyInfo getMyInfo(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        return new UserResponse.MyInfo(user.getEmail(), user.getName());
+    }
+}
+

--- a/src/main/java/com/project/team5backend/domain/user/service/query/UserQueryServiceImpl.java
+++ b/src/main/java/com/project/team5backend/domain/user/service/query/UserQueryServiceImpl.java
@@ -1,5 +1,6 @@
 package com.project.team5backend.domain.user.service.query;
 
+import com.project.team5backend.domain.user.converter.UserConverter;
 import com.project.team5backend.domain.user.dto.response.UserResponse;
 import com.project.team5backend.domain.user.entity.User;
 import com.project.team5backend.domain.user.repository.UserRepository;
@@ -11,12 +12,13 @@ import org.springframework.stereotype.Service;
 public class UserQueryServiceImpl implements UserQueryService {
 
     private final UserRepository userRepository;
+    private final UserConverter userConverter;
 
     @Override
     public UserResponse.MyInfo getMyInfo(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
-        return new UserResponse.MyInfo(user.getId(),user.getName(),user.getEmail(),user.getCreatedAt(),user.getUpdatedAt());
+        return userConverter.toMyInfo(user);
     }
 }
 

--- a/src/main/java/com/project/team5backend/global/BaseEntity.java
+++ b/src/main/java/com/project/team5backend/global/BaseEntity.java
@@ -1,0 +1,25 @@
+package com.project.team5backend.global;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}
+

--- a/src/main/java/com/project/team5backend/global/apiPayload/CustomResponse.java
+++ b/src/main/java/com/project/team5backend/global/apiPayload/CustomResponse.java
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
+@Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @JsonPropertyOrder({"isSuccess", "code", "message", "result"})
 public class CustomResponse<T> {

--- a/src/main/java/com/project/team5backend/global/apiPayload/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/project/team5backend/global/apiPayload/exception/handler/GlobalExceptionHandler.java
@@ -21,14 +21,15 @@ public class GlobalExceptionHandler {
     //애플리케이션에서 발생하는 커스텀 예외를 처리
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<CustomResponse<Void>> handleCustomException(CustomException ex) {
+        BaseErrorCode errorCode = ex.getCode();
         //예외가 발생하면 로그 기록
         log.warn("[ CustomException ]: {}", ex.getCode().getMessage());
         //커스텀 예외에 정의된 에러 코드와 메시지를 포함한 응답 제공
         return ResponseEntity
-                .status(ex.getCode().getHttpStatus())
-                .body(ex.getCode().getErrorResponse());
+                .status(errorCode.getHttpStatus())
+                .body(errorCode.getErrorResponse());
     }
-    // MethodArgumentNotValidException
+    // MethodArgumentNotValidException- DTO 유효성 검사 실패
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<CustomResponse<Map<String, String>>> handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
         log.warn("[ Validation Error - MethodArgumentNotValidException ]: {}", ex.getMessage());
@@ -39,7 +40,8 @@ public class GlobalExceptionHandler {
         });
 
         BaseErrorCode errorCode = GeneralErrorCode.VALIDATION_FAILED_DTO;
-        CustomResponse<Map<String, String>> errorResponse = CustomResponse.onFailure(errorCode.getCode(), errorCode.getMessage(), errors);
+        CustomResponse<Map<String, String>> errorResponse = CustomResponse.onFailure(
+                errorCode.getCode(), errorCode.getMessage(), errors);
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
                 .body(errorResponse);
@@ -57,7 +59,8 @@ public class GlobalExceptionHandler {
         });
 
         BaseErrorCode errorCode = GeneralErrorCode.VALIDATION_FAILED_PARAM;
-        CustomResponse<Map<String, String>> errorResponse = CustomResponse.onFailure(errorCode.getCode(), errorCode.getMessage(), errors);
+        CustomResponse<Map<String, String>> errorResponse = CustomResponse.onFailure(
+                errorCode.getCode(), errorCode.getMessage(), errors);
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
                 .body(errorResponse);
@@ -66,7 +69,7 @@ public class GlobalExceptionHandler {
     // 그 외의 정의되지 않은 모든 예외 처리
     @ExceptionHandler({Exception.class})
     public ResponseEntity<CustomResponse<String>> handleAllException(Exception ex) {
-        log.error("[WARNING] Internal Server Error : {} ", ex.getMessage());
+        log.error("[WARNING] Internal Server Error : {} ", ex.getMessage(),ex);
         BaseErrorCode errorCode = GeneralErrorCode.INTERNAL_SERVER_ERROR_500;
         CustomResponse<String> errorResponse = CustomResponse.onFailure(
                 errorCode.getCode(),

--- a/src/main/java/com/project/team5backend/global/config/RedisConfig.java
+++ b/src/main/java/com/project/team5backend/global/config/RedisConfig.java
@@ -1,0 +1,38 @@
+package com.project.team5backend.global.config;
+
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    // Redis 접속 정보 설정
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        // 기본값은 localhost:6379 (도커 쓰면 host.docker.internal 또는 redis 이름일 수도 있음)
+        return new LettuceConnectionFactory("localhost", 6379);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+
+        // Key와 Value는 모두 String 기반 (필요시 JSON Serializer로 교체 가능)
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/project/team5backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/project/team5backend/global/config/SecurityConfig.java
@@ -22,8 +22,8 @@ public class SecurityConfig {
                 .httpBasic(httpBasic -> httpBasic.disable())
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
-                                "/api/auth/**",           // 기존 인증 허용 경로
-                                "/api/users/**",
+                                "/api/v1/auth/**",           // 기존 인증 허용 경로
+                                "/api/v1/users/**",
                                 "/swagger-ui/**",         // ✅ Swagger UI
                                 "/v3/api-docs/**",        // ✅ Swagger Docs
                                 "/swagger-resources/**",  // ✅ Swagger Resources

--- a/src/main/java/com/project/team5backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/project/team5backend/global/config/SecurityConfig.java
@@ -1,0 +1,36 @@
+package com.project.team5backend.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable()) // 개발 중 csrf 비활성화 (배포 전 조정 필요)
+                .formLogin(form -> form.disable())
+                .httpBasic(httpBasic -> httpBasic.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/api/auth/**",           // 기존 인증 허용 경로
+                                "/swagger-ui/**",         // ✅ Swagger UI
+                                "/v3/api-docs/**",        // ✅ Swagger Docs
+                                "/swagger-resources/**",  // ✅ Swagger Resources
+                                "/webjars/**"             // ✅ Swagger Webjars
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                );
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/project/team5backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/project/team5backend/global/config/SecurityConfig.java
@@ -6,6 +6,11 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
 
 @Configuration
 public class SecurityConfig {
@@ -18,13 +23,15 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/api/auth/**",           // 기존 인증 허용 경로
+                                "/api/users/**",
                                 "/swagger-ui/**",         // ✅ Swagger UI
                                 "/v3/api-docs/**",        // ✅ Swagger Docs
                                 "/swagger-resources/**",  // ✅ Swagger Resources
                                 "/webjars/**"             // ✅ Swagger Webjars
                         ).permitAll()
                         .anyRequest().authenticated()
-                );
+                )
+                .cors(cors -> {});;
 
         return http.build();
     }
@@ -32,5 +39,18 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+    @Bean // 이 부분을 추가해야 합니다.
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        // 실제 클라이언트 도메인으로 변경해야 합니다. 와일드카드(*)는 배포 시 보안 문제의 소지가 있습니다.
+        configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000"));
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
+        configuration.setAllowedHeaders(Arrays.asList("*"));
+        configuration.setAllowCredentials(true); // 이 부분이 쿠키를 허용하는 가장 중요한 설정입니다.
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }

--- a/src/main/java/com/project/team5backend/global/config/SessionConfig.java
+++ b/src/main/java/com/project/team5backend/global/config/SessionConfig.java
@@ -1,0 +1,17 @@
+package com.project.team5backend.global.config;
+
+import com.project.team5backend.domain.user.entity.User;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Configuration
+public class SessionConfig {
+
+    @Bean
+    public Map<String, User> sessionStore() {
+        return new ConcurrentHashMap<>();
+    }
+}

--- a/src/main/java/com/project/team5backend/global/config/SwaggerConfig.java
+++ b/src/main/java/com/project/team5backend/global/config/SwaggerConfig.java
@@ -1,4 +1,4 @@
-package com.project.team5backend.global;
+package com.project.team5backend.global.config;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;

--- a/src/main/java/com/project/team5backend/global/util/CookieUtil.java
+++ b/src/main/java/com/project/team5backend/global/util/CookieUtil.java
@@ -1,0 +1,16 @@
+package com.project.team5backend.global.util;
+
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class CookieUtil {
+
+    public static void addCookie(HttpServletResponse response, String key, String value, int maxAge) {
+        Cookie cookie = new Cookie(key, value);
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(maxAge);
+        response.addCookie(cookie);
+    }
+}


### PR DESCRIPTION
# ☝️Issue Number

- #6 

##  📌 개요

- 회원가입, 로그인, 이메일 검증, 회원 정보 조회, 회원 정보 수정, 비밀번호 변경, 회원 탈퇴 구현

## 🔁 변경 사항
- 카카오 소셜 로그인 기능은 안하기로 했음
## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
- 이메일 검증 되면 "is_email_verified"가 true/fasle 가 되야하는데 현재 DB에 따로 표시 안되고 있음... 이것만 해결하면 될듯!