### PR TITLE
Feat/#4 image 등록 로직 전시 crd api에 적용

### DIFF
--- a/src/main/java/com/project/team5backend/domain/exhibition/exhibition/controller/ExhibitionController.java
+++ b/src/main/java/com/project/team5backend/domain/exhibition/exhibition/controller/ExhibitionController.java
@@ -33,6 +33,11 @@ public class ExhibitionController {
             @RequestBody ExhibitionReqDTO.CreateExhibitionReqDTO createExhibitionReqDTO) {
         return CustomResponse.onSuccess(exhibitionCommandService.previewExhibition(createExhibitionReqDTO));
     }
+    @PostMapping("/{exhibitionId}/like")
+    @Operation(summary = "전시 좋아요", description = "좋아요 없으면 등록, 있으면 취소")
+    public CustomResponse<ExhibitionResDTO.LikeExhibitionResDTO> likeExhibition(@PathVariable Long exhibitionId) {
+        return CustomResponse.onSuccess(exhibitionCommandService.likeExhibition(exhibitionId));
+    }
 
     @GetMapping("/{exhibitionId}")
     @Operation(summary = "전시 상세 보기", description = "전시 상세 보기 api")

--- a/src/main/java/com/project/team5backend/domain/exhibition/exhibition/controller/ExhibitionController.java
+++ b/src/main/java/com/project/team5backend/domain/exhibition/exhibition/controller/ExhibitionController.java
@@ -42,7 +42,7 @@ public class ExhibitionController {
     @GetMapping("/{exhibitionId}")
     @Operation(summary = "전시 상세 보기", description = "전시 상세 보기 api")
     public CustomResponse<ExhibitionResDTO.DetailExhibitionResDTO> detailExhibition(@PathVariable Long exhibitionId) {
-        return CustomResponse.onSuccess(exhibitionQueryService.detailExhibition(exhibitionId));
+        return CustomResponse.onSuccess(exhibitionQueryService.getDetailExhibition(exhibitionId));
     }
 
     @DeleteMapping("/{exhibitionId}")

--- a/src/main/java/com/project/team5backend/domain/exhibition/exhibition/controller/ExhibitionController.java
+++ b/src/main/java/com/project/team5backend/domain/exhibition/exhibition/controller/ExhibitionController.java
@@ -31,7 +31,7 @@ public class ExhibitionController {
     @Operation(summary = "전시 생성 중 미리보기", description = "작성중 미리보기 api")
     public CustomResponse<ExhibitionResDTO.PreviewExhibitionResDTO> previewExhibition(
             @RequestBody ExhibitionReqDTO.CreateExhibitionReqDTO createExhibitionReqDTO) {
-        return CustomResponse.onSuccess(exhibitionCommandService.previewExhibition(createExhibitionReqDTO));
+        return CustomResponse.onSuccess(exhibitionCommandService.previewExhibition("likelion@naver.com",createExhibitionReqDTO));
     }
     @PostMapping("/{exhibitionId}/like")
     @Operation(summary = "전시 좋아요", description = "좋아요 없으면 등록, 있으면 취소")

--- a/src/main/java/com/project/team5backend/domain/exhibition/exhibition/controller/ExhibitionController.java
+++ b/src/main/java/com/project/team5backend/domain/exhibition/exhibition/controller/ExhibitionController.java
@@ -48,7 +48,8 @@ public class ExhibitionController {
     @DeleteMapping("/{exhibitionId}")
     @Operation(summary = "전시 삭제", description = "전시가 삭제된 전시로 변경하는 api")
     public CustomResponse<String> deleteExhibition(@PathVariable Long exhibitionId){
-        exhibitionCommandService.deleteExhibition(exhibitionId);
+        //유저 검증 로직 필요
+        exhibitionCommandService.deleteExhibition(4L);
         return CustomResponse.onSuccess("해당 전시가 삭제되었습니다.");
     }
 }

--- a/src/main/java/com/project/team5backend/domain/exhibition/exhibition/converter/ExhibitionConverter.java
+++ b/src/main/java/com/project/team5backend/domain/exhibition/exhibition/converter/ExhibitionConverter.java
@@ -74,9 +74,7 @@ public class ExhibitionConverter {
                 .mood(exhibition.getMood())
                 .price(exhibition.getPrice())
                 .facility(exhibition.getFacilities())
-                .reviews(exhibition.getReviews().stream()
-                        .map(ExhibitionConverter::toReviewPreview)
-                        .toList())
+                .reviews(null)
                 .build();
     }
 

--- a/src/main/java/com/project/team5backend/domain/exhibition/exhibition/converter/ExhibitionConverter.java
+++ b/src/main/java/com/project/team5backend/domain/exhibition/exhibition/converter/ExhibitionConverter.java
@@ -6,10 +6,15 @@ import com.project.team5backend.domain.exhibition.exhibition.entity.Exhibition;
 import com.project.team5backend.domain.exhibition.exhibition.entity.enums.Status;
 import com.project.team5backend.domain.exhibition.review.entity.ExhibitionReview;
 import com.project.team5backend.domain.user.entity.User;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ExhibitionConverter {
 
-    public static Exhibition toEntity (User user, ExhibitionReqDTO.CreateExhibitionReqDTO createReqDTO) {
+    public static Exhibition toEntity (User user, ExhibitionReqDTO.CreateExhibitionReqDTO createReqDTO, String fileKey) {
         return Exhibition.builder()
                 .title(createReqDTO.title())
                 .description(createReqDTO.description())
@@ -27,7 +32,7 @@ public class ExhibitionConverter {
                 .ratingAvg(0)
                 .likeCount(0)
                 .reviewCount(0)
-                .thumbnail(null)
+                .thumbnail(fileKey)
                 .address(null)
                 .user(user)
                 .build();
@@ -51,7 +56,7 @@ public class ExhibitionConverter {
                 .build();
     }
 
-    public static ExhibitionResDTO.DetailExhibitionResDTO toDetailExhibitionResDTO(Exhibition exhibition) {
+    public static ExhibitionResDTO.DetailExhibitionResDTO toDetailExhibitionResDTO(Exhibition exhibition, List<String> imageFileKeys) {
         return ExhibitionResDTO.DetailExhibitionResDTO.builder()
                 .exhibitionId(exhibition.getId())
                 .title(exhibition.getTitle())
@@ -59,7 +64,7 @@ public class ExhibitionConverter {
                 .startDate(exhibition.getStartDate())
                 .endDate(exhibition.getEndDate())
                 .openingTime(exhibition.getOpeningTime())
-                .imageUrls(null)
+                .imageFileKeys(imageFileKeys)
                 .homepageUrl(exhibition.getHomepageUrl())
                 .address(
                         exhibition.getAddress() != null ? exhibition.getAddress().toString() : null

--- a/src/main/java/com/project/team5backend/domain/exhibition/exhibition/converter/ExhibitionConverter.java
+++ b/src/main/java/com/project/team5backend/domain/exhibition/exhibition/converter/ExhibitionConverter.java
@@ -38,14 +38,14 @@ public class ExhibitionConverter {
                 .build();
     }
 
-    public static ExhibitionResDTO.PreviewExhibitionResDTO toPreviewExhibitionResDTO (ExhibitionReqDTO.CreateExhibitionReqDTO createReqDTO) {
+    public static ExhibitionResDTO.PreviewExhibitionResDTO toPreviewExhibitionResDTO (ExhibitionReqDTO.CreateExhibitionReqDTO createReqDTO, List<String> images) {
         return ExhibitionResDTO.PreviewExhibitionResDTO.builder()
                 .title(createReqDTO.title())
                 .description(createReqDTO.description())
                 .startDate(createReqDTO.startDate())
                 .endDate(createReqDTO.endDate())
                 .openingTime(createReqDTO.openingHour())
-                .imageUrls(null)
+                .imageUrls(images)
                 .homepageUrl(createReqDTO.homepageUrl())
                 .price(createReqDTO.price())
                 .address(createReqDTO.address())

--- a/src/main/java/com/project/team5backend/domain/exhibition/exhibition/converter/ExhibitionLikeConverter.java
+++ b/src/main/java/com/project/team5backend/domain/exhibition/exhibition/converter/ExhibitionLikeConverter.java
@@ -1,0 +1,24 @@
+package com.project.team5backend.domain.exhibition.exhibition.converter;
+
+import com.project.team5backend.domain.exhibition.exhibition.dto.response.ExhibitionResDTO;
+import com.project.team5backend.domain.exhibition.exhibition.entity.Exhibition;
+import com.project.team5backend.domain.exhibition.exhibition.entity.ExhibitionLike;
+import com.project.team5backend.domain.user.entity.User;
+
+public class ExhibitionLikeConverter {
+
+    public static ExhibitionLike toEntity (User user, Exhibition exhibition) {
+        return ExhibitionLike.builder()
+                .user(user)
+                .exhibition(exhibition)
+                .build();
+    }
+
+    public static ExhibitionResDTO.LikeExhibitionResDTO toLikeExhibitionResDTO(Long exhibitionId, String message) {
+        return ExhibitionResDTO.LikeExhibitionResDTO.builder()
+                .exhibitionId(exhibitionId)
+                .message(message)
+                .build();
+    }
+
+}

--- a/src/main/java/com/project/team5backend/domain/exhibition/exhibition/converter/ExhibitionLikeConverter.java
+++ b/src/main/java/com/project/team5backend/domain/exhibition/exhibition/converter/ExhibitionLikeConverter.java
@@ -4,7 +4,10 @@ import com.project.team5backend.domain.exhibition.exhibition.dto.response.Exhibi
 import com.project.team5backend.domain.exhibition.exhibition.entity.Exhibition;
 import com.project.team5backend.domain.exhibition.exhibition.entity.ExhibitionLike;
 import com.project.team5backend.domain.user.entity.User;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ExhibitionLikeConverter {
 
     public static ExhibitionLike toEntity (User user, Exhibition exhibition) {

--- a/src/main/java/com/project/team5backend/domain/exhibition/exhibition/dto/response/ExhibitionResDTO.java
+++ b/src/main/java/com/project/team5backend/domain/exhibition/exhibition/dto/response/ExhibitionResDTO.java
@@ -36,7 +36,7 @@ public class ExhibitionResDTO {
             LocalDate startDate,
             LocalDate endDate,
             String openingTime,
-            List<String> imageUrls,
+            List<String> imageFileKeys,
             String homepageUrl,
             String address,
             Category category,

--- a/src/main/java/com/project/team5backend/domain/exhibition/exhibition/dto/response/ExhibitionResDTO.java
+++ b/src/main/java/com/project/team5backend/domain/exhibition/exhibition/dto/response/ExhibitionResDTO.java
@@ -56,4 +56,9 @@ public class ExhibitionResDTO {
             LocalDate createdAt
     ) {}
 
+    @Builder
+    public record LikeExhibitionResDTO (
+            Long exhibitionId,
+            String message
+    ){}
 }

--- a/src/main/java/com/project/team5backend/domain/exhibition/exhibition/entity/Exhibition.java
+++ b/src/main/java/com/project/team5backend/domain/exhibition/exhibition/entity/Exhibition.java
@@ -91,4 +91,11 @@ public class Exhibition extends BaseTimeEntity {
         isDeleted = true;
     }
 
+    public void increaseLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decreaseLikeCount() {
+        this.likeCount = Math.max(0, this.likeCount - 1);
+    }
 }

--- a/src/main/java/com/project/team5backend/domain/exhibition/exhibition/entity/Exhibition.java
+++ b/src/main/java/com/project/team5backend/domain/exhibition/exhibition/entity/Exhibition.java
@@ -84,9 +84,6 @@ public class Exhibition extends BaseTimeEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
-    @OneToMany(mappedBy = "exhibition", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<ExhibitionReview> reviews = new ArrayList<>();
-
     public void delete() {
         isDeleted = true;
     }
@@ -97,5 +94,10 @@ public class Exhibition extends BaseTimeEntity {
 
     public void decreaseLikeCount() {
         this.likeCount = Math.max(0, this.likeCount - 1);
+    }
+
+    public void resetCount() {
+        this.likeCount = 0;
+        this.reviewCount = 0;
     }
 }

--- a/src/main/java/com/project/team5backend/domain/exhibition/exhibition/entity/ExhibitionLike.java
+++ b/src/main/java/com/project/team5backend/domain/exhibition/exhibition/entity/ExhibitionLike.java
@@ -1,0 +1,29 @@
+package com.project.team5backend.domain.exhibition.exhibition.entity;
+
+import com.project.team5backend.domain.user.entity.User;
+import com.project.team5backend.global.entity.BaseOnlyCreateTimeEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ExhibitionLike extends BaseOnlyCreateTimeEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "exhibition_liked_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "exhibition_id")
+    private Exhibition exhibition;
+}

--- a/src/main/java/com/project/team5backend/domain/exhibition/exhibition/repository/ExhibitionLikeRepository.java
+++ b/src/main/java/com/project/team5backend/domain/exhibition/exhibition/repository/ExhibitionLikeRepository.java
@@ -13,4 +13,8 @@ public interface ExhibitionLikeRepository extends JpaRepository<ExhibitionLike, 
     @Modifying
     @Query("delete from ExhibitionLike el where el.user.id =:userId and el.exhibition.id =:exhibitionId")
     void deleteByUserIdAndExhibitionId(@Param("userId") Long userId,@Param("exhibitionId") Long exhibitionId);
+
+    @Modifying
+    @Query("delete from ExhibitionLike ei where ei.exhibition.id =:exhibitionId")
+    void deleteByExhibitionId(@Param("exhibitionId") Long exhibitionId);
 }

--- a/src/main/java/com/project/team5backend/domain/exhibition/exhibition/repository/ExhibitionLikeRepository.java
+++ b/src/main/java/com/project/team5backend/domain/exhibition/exhibition/repository/ExhibitionLikeRepository.java
@@ -1,0 +1,16 @@
+package com.project.team5backend.domain.exhibition.exhibition.repository;
+
+import com.project.team5backend.domain.exhibition.exhibition.entity.ExhibitionLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ExhibitionLikeRepository extends JpaRepository<ExhibitionLike, Long> {
+
+    Boolean existsByUserIdAndExhibitionId(@Param("userId") Long userId, @Param("exhibitionId") Long exhibitionId);
+
+    @Modifying
+    @Query("delete from ExhibitionLike el where el.user.id =:userId and el.exhibition.id =:exhibitionId")
+    void deleteByUserIdAndExhibitionId(@Param("userId") Long userId,@Param("exhibitionId") Long exhibitionId);
+}

--- a/src/main/java/com/project/team5backend/domain/exhibition/exhibition/service/command/ExhibitionCommandService.java
+++ b/src/main/java/com/project/team5backend/domain/exhibition/exhibition/service/command/ExhibitionCommandService.java
@@ -7,6 +7,8 @@ public interface ExhibitionCommandService {
 
     void createExhibition(ExhibitionReqDTO.CreateExhibitionReqDTO createExhibitionReqDTO);
 
+    ExhibitionResDTO.LikeExhibitionResDTO likeExhibition(Long exhibitionId);
+
     ExhibitionResDTO.PreviewExhibitionResDTO previewExhibition(ExhibitionReqDTO.CreateExhibitionReqDTO createExhibitionReqDTO);
 
     void deleteExhibition(Long id);

--- a/src/main/java/com/project/team5backend/domain/exhibition/exhibition/service/command/ExhibitionCommandService.java
+++ b/src/main/java/com/project/team5backend/domain/exhibition/exhibition/service/command/ExhibitionCommandService.java
@@ -9,7 +9,7 @@ public interface ExhibitionCommandService {
 
     ExhibitionResDTO.LikeExhibitionResDTO likeExhibition(Long exhibitionId);
 
-    ExhibitionResDTO.PreviewExhibitionResDTO previewExhibition(ExhibitionReqDTO.CreateExhibitionReqDTO createExhibitionReqDTO);
+    ExhibitionResDTO.PreviewExhibitionResDTO previewExhibition(String email, ExhibitionReqDTO.CreateExhibitionReqDTO createExhibitionReqDTO);
 
     void deleteExhibition(Long id);
 }

--- a/src/main/java/com/project/team5backend/domain/exhibition/exhibition/service/command/ExhibitionCommandServiceImpl.java
+++ b/src/main/java/com/project/team5backend/domain/exhibition/exhibition/service/command/ExhibitionCommandServiceImpl.java
@@ -85,8 +85,9 @@ public class ExhibitionCommandServiceImpl implements ExhibitionCommandService {
 
 
     @Override
-    public ExhibitionResDTO.PreviewExhibitionResDTO previewExhibition(ExhibitionReqDTO.CreateExhibitionReqDTO createExhibitionReqDTO){
-        return ExhibitionConverter.toPreviewExhibitionResDTO(createExhibitionReqDTO);
+    public ExhibitionResDTO.PreviewExhibitionResDTO previewExhibition(String email, ExhibitionReqDTO.CreateExhibitionReqDTO createExhibitionReqDTO){
+        List<String> images = redisImageTracker.getOrderedFileKeysByEmail(email);
+        return ExhibitionConverter.toPreviewExhibitionResDTO(createExhibitionReqDTO, images);
     }
 
     @Override

--- a/src/main/java/com/project/team5backend/domain/exhibition/exhibition/service/command/ExhibitionCommandServiceImpl.java
+++ b/src/main/java/com/project/team5backend/domain/exhibition/exhibition/service/command/ExhibitionCommandServiceImpl.java
@@ -1,14 +1,18 @@
 package com.project.team5backend.domain.exhibition.exhibition.service.command;
 
 import com.project.team5backend.domain.exhibition.exhibition.converter.ExhibitionConverter;
+import com.project.team5backend.domain.exhibition.exhibition.converter.ExhibitionLikeConverter;
 import com.project.team5backend.domain.exhibition.exhibition.dto.request.ExhibitionReqDTO;
 import com.project.team5backend.domain.exhibition.exhibition.dto.response.ExhibitionResDTO;
 import com.project.team5backend.domain.exhibition.exhibition.entity.Exhibition;
 import com.project.team5backend.domain.exhibition.exhibition.exception.ExhibitionErrorCode;
 import com.project.team5backend.domain.exhibition.exhibition.exception.ExhibitionException;
+import com.project.team5backend.domain.exhibition.exhibition.repository.ExhibitionLikeRepository;
 import com.project.team5backend.domain.exhibition.exhibition.repository.ExhibitionRepository;
 import com.project.team5backend.domain.user.entity.User;
 import com.project.team5backend.domain.user.repository.UserRepository;
+import com.project.team5backend.global.apiPayload.code.GeneralErrorCode;
+import com.project.team5backend.global.apiPayload.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -23,6 +27,7 @@ public class ExhibitionCommandServiceImpl implements ExhibitionCommandService {
 
     private final ExhibitionRepository exhibitionRepository;
     private final UserRepository userRepository;
+    private final ExhibitionLikeRepository exhibitionLikeRepository;
 
     @Override
     public void createExhibition(ExhibitionReqDTO.CreateExhibitionReqDTO createExhibitionReqDTO) {
@@ -32,6 +37,28 @@ public class ExhibitionCommandServiceImpl implements ExhibitionCommandService {
 
         exhibitionRepository.save(ex);
     }
+
+    @Override
+    public ExhibitionResDTO.LikeExhibitionResDTO likeExhibition(Long exhibitionId) {
+        User user = userRepository.findById(1L)
+                .orElseThrow(()-> new CustomException(GeneralErrorCode.NOT_FOUND_404));
+
+        Exhibition exhibition = exhibitionRepository.findById(exhibitionId)
+                .orElseThrow(()-> new CustomException(GeneralErrorCode.NOT_FOUND_404));
+
+        if (exhibitionLikeRepository.existsByUserIdAndExhibitionId(user.getId(), exhibition.getId())) {
+            //좋아요 취소
+            exhibitionLikeRepository.deleteByUserIdAndExhibitionId(user.getId(), exhibitionId);
+            exhibition.decreaseLikeCount();
+            return ExhibitionLikeConverter.toLikeExhibitionResDTO(exhibitionId, "관심목록에서 삭제되었습니다.");
+        }else {
+            //좋아요 등록
+            exhibitionLikeRepository.save(ExhibitionLikeConverter.toEntity(user, exhibition));
+            exhibition.increaseLikeCount();
+            return ExhibitionLikeConverter.toLikeExhibitionResDTO(exhibitionId, "관심목록에 추가되었습니다.");
+        }
+    }
+
 
     @Override
     public ExhibitionResDTO.PreviewExhibitionResDTO previewExhibition(ExhibitionReqDTO.CreateExhibitionReqDTO createExhibitionReqDTO){

--- a/src/main/java/com/project/team5backend/domain/exhibition/exhibition/service/query/ExhibitionQueryService.java
+++ b/src/main/java/com/project/team5backend/domain/exhibition/exhibition/service/query/ExhibitionQueryService.java
@@ -4,5 +4,5 @@ import com.project.team5backend.domain.exhibition.exhibition.dto.response.Exhibi
 
 public interface ExhibitionQueryService {
 
-    ExhibitionResDTO.DetailExhibitionResDTO detailExhibition(Long id);
+    ExhibitionResDTO.DetailExhibitionResDTO getDetailExhibition(Long id);
 }

--- a/src/main/java/com/project/team5backend/domain/exhibition/exhibition/service/query/ExhibitionQueryServiceImpl.java
+++ b/src/main/java/com/project/team5backend/domain/exhibition/exhibition/service/query/ExhibitionQueryServiceImpl.java
@@ -6,10 +6,14 @@ import com.project.team5backend.domain.exhibition.exhibition.entity.Exhibition;
 import com.project.team5backend.domain.exhibition.exhibition.exception.ExhibitionErrorCode;
 import com.project.team5backend.domain.exhibition.exhibition.exception.ExhibitionException;
 import com.project.team5backend.domain.exhibition.exhibition.repository.ExhibitionRepository;
+import com.project.team5backend.domain.image.converter.ImageConverter;
+import com.project.team5backend.domain.image.repository.ExhibitionImageRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -18,11 +22,16 @@ import org.springframework.transaction.annotation.Transactional;
 public class ExhibitionQueryServiceImpl implements ExhibitionQueryService {
 
     private final ExhibitionRepository exhibitionRepository;
+    private final ExhibitionImageRepository exhibitionImageRepository;
     @Override
-    public ExhibitionResDTO.DetailExhibitionResDTO detailExhibition(Long id) {
+    public ExhibitionResDTO.DetailExhibitionResDTO getDetailExhibition(Long id) {
         Exhibition exhibition = exhibitionRepository.findById(id)
                 .orElseThrow(() -> new ExhibitionException(ExhibitionErrorCode.EXHIBITION_NOT_FOUND));
-        return ExhibitionConverter.toDetailExhibitionResDTO(exhibition);
+
+        // 전시 이미지들의 fileKey만 조회
+        List<String> imageFileKeys = exhibitionImageRepository.findFileKeysByExhibitionId(2L);
+
+        return ExhibitionConverter.toDetailExhibitionResDTO(exhibition, imageFileKeys);
     }
 
 }

--- a/src/main/java/com/project/team5backend/domain/exhibition/exhibition/service/query/ExhibitionQueryServiceImpl.java
+++ b/src/main/java/com/project/team5backend/domain/exhibition/exhibition/service/query/ExhibitionQueryServiceImpl.java
@@ -6,7 +6,6 @@ import com.project.team5backend.domain.exhibition.exhibition.entity.Exhibition;
 import com.project.team5backend.domain.exhibition.exhibition.exception.ExhibitionErrorCode;
 import com.project.team5backend.domain.exhibition.exhibition.exception.ExhibitionException;
 import com.project.team5backend.domain.exhibition.exhibition.repository.ExhibitionRepository;
-import com.project.team5backend.domain.image.converter.ImageConverter;
 import com.project.team5backend.domain.image.repository.ExhibitionImageRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/project/team5backend/domain/exhibition/review/repository/ExhibitionReviewRepository.java
+++ b/src/main/java/com/project/team5backend/domain/exhibition/review/repository/ExhibitionReviewRepository.java
@@ -2,6 +2,12 @@ package com.project.team5backend.domain.exhibition.review.repository;
 
 import com.project.team5backend.domain.exhibition.review.entity.ExhibitionReview;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ExhibitionReviewRepository extends JpaRepository<ExhibitionReview, Long> {
+    @Modifying
+    @Query("update ExhibitionReview er set er.isDeleted = true where er.exhibition.id =:exhibitionId")
+    void softDeleteByExhibitionId(@Param("exhibitionId") Long exhibitionId);
 }

--- a/src/main/java/com/project/team5backend/domain/image/controller/ImageController.java
+++ b/src/main/java/com/project/team5backend/domain/image/controller/ImageController.java
@@ -2,6 +2,8 @@ package com.project.team5backend.domain.image.controller;
 
 import com.project.team5backend.domain.image.dto.request.ImageReqDTO;
 import com.project.team5backend.domain.image.dto.response.ImageResDTO;
+import com.project.team5backend.domain.image.exception.ImageErrorCode;
+import com.project.team5backend.domain.image.exception.ImageException;
 import com.project.team5backend.domain.image.service.RedisImageTracker;
 import com.project.team5backend.domain.image.service.command.ImageCommandService;
 import com.project.team5backend.global.apiPayload.CustomResponse;
@@ -34,6 +36,9 @@ public class ImageController {
             @RequestParam("fileKey") String fileKey
     ) {
         String email = "likelion@naver.com";
+        if (!redisImageTracker.isOwnedByUser(email, fileKey)) {
+            throw new ImageException(ImageErrorCode.IMAGE_UNAUTHORIZED);
+        }
         return CustomResponse.onSuccess(imageCommandService.delete(email, fileKey));
     }
 

--- a/src/main/java/com/project/team5backend/domain/image/controller/ImageController.java
+++ b/src/main/java/com/project/team5backend/domain/image/controller/ImageController.java
@@ -2,6 +2,7 @@ package com.project.team5backend.domain.image.controller;
 
 import com.project.team5backend.domain.image.dto.request.ImageReqDTO;
 import com.project.team5backend.domain.image.dto.response.ImageResDTO;
+import com.project.team5backend.domain.image.service.RedisImageTracker;
 import com.project.team5backend.domain.image.service.command.ImageCommandService;
 import com.project.team5backend.global.apiPayload.CustomResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 public class ImageController {
 
     private final ImageCommandService imageCommandService;
+    private final RedisImageTracker redisImageTracker;
 
     @Operation(method = "POST", summary = "이미지 업로드", description = "presigned url과 fileKey 발급용, 업로드 하는건 아님")
     @PostMapping("/presigned")
@@ -33,5 +35,12 @@ public class ImageController {
     ) {
         String email = "likelion@naver.com";
         return CustomResponse.onSuccess(imageCommandService.delete(email, fileKey));
+    }
+
+    @Operation(method = "DELETE", summary = "이미지 업로드 전 쓰레기 이미지 정리", description = "항상 XX(전시,리뷰,공간) 등록 화면에 들어갈 때 실행해야함.")
+    @DeleteMapping("/trash/clear")
+    public CustomResponse<String> clearTrashImages() {
+        redisImageTracker.clearUserImages("likelion@naver.com");
+        return CustomResponse.onSuccess("쓰레기 키파일 정리 완료");
     }
 }

--- a/src/main/java/com/project/team5backend/domain/image/controller/ImageController.java
+++ b/src/main/java/com/project/team5backend/domain/image/controller/ImageController.java
@@ -36,6 +36,7 @@ public class ImageController {
             @RequestParam("fileKey") String fileKey
     ) {
         String email = "likelion@naver.com";
+
         if (!redisImageTracker.isOwnedByUser(email, fileKey)) {
             throw new ImageException(ImageErrorCode.IMAGE_UNAUTHORIZED);
         }
@@ -45,7 +46,7 @@ public class ImageController {
     @Operation(method = "DELETE", summary = "이미지 업로드 전 쓰레기 이미지 정리", description = "항상 XX(전시,리뷰,공간) 등록 화면에 들어갈 때 실행해야함.")
     @DeleteMapping("/trash/clear")
     public CustomResponse<String> clearTrashImages() {
-        redisImageTracker.clearUserImages("likelion@naver.com");
+        imageCommandService.clearTrackingByEmail("likelion@naver.com");
         return CustomResponse.onSuccess("쓰레기 키파일 정리 완료");
     }
 }

--- a/src/main/java/com/project/team5backend/domain/image/converter/ImageConverter.java
+++ b/src/main/java/com/project/team5backend/domain/image/converter/ImageConverter.java
@@ -1,7 +1,9 @@
 package com.project.team5backend.domain.image.converter;
 
+import com.project.team5backend.domain.exhibition.exhibition.entity.Exhibition;
 import com.project.team5backend.domain.image.dto.internel.ImageInternelDTO;
 import com.project.team5backend.domain.image.dto.response.ImageResDTO;
+import com.project.team5backend.domain.image.entity.ExhibitionImage;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
@@ -10,10 +12,22 @@ import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignReques
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ImageConverter {
+    public static ExhibitionImage toEntityExhibitionImage(Exhibition exhibition, String fileKey) {
+        return ExhibitionImage.builder()
+                .fileKey(fileKey)
+                .isDeleted(false)
+                .exhibition(exhibition)
+                .build();
+    }
+    public static List<String> toFileKeyList(List<ExhibitionImage> exhibitionImages) {
+        return exhibitionImages.stream().map(ExhibitionImage::getFileKey).collect(Collectors.toList());
+    }
+
     public static ImageResDTO.PresignedUrlResDTO toPresignedUrlResDTO(String presignedUrl, String fileKey) {
         return ImageResDTO.PresignedUrlResDTO.builder()
                 .presignedUrl(presignedUrl)

--- a/src/main/java/com/project/team5backend/domain/image/dto/request/ImageReqDTO.java
+++ b/src/main/java/com/project/team5backend/domain/image/dto/request/ImageReqDTO.java
@@ -16,10 +16,4 @@ public class ImageReqDTO {
     public record PresignedUrlListReqDTO(
             List<PresignedUrlReqDTO> images // 각 이미지마다 contentType, fileExtension
     ){}
-
-    @Builder
-    public record SaveImageReqDTO(
-            String fileKey
-    ){
-    }
 }

--- a/src/main/java/com/project/team5backend/domain/image/dto/response/ImageResDTO.java
+++ b/src/main/java/com/project/team5backend/domain/image/dto/response/ImageResDTO.java
@@ -21,11 +21,10 @@ public class ImageResDTO {
     ){}
 
     @Builder
-    public record SaveImageResDTO (
-            String profileImageUrl,
-            String message
-    ){
-    }
+    public record FileKeyListResDTO (
+            List<String> fileKeys
+    ){}
+
     @Builder
     public record DeleteImageResDTO(
             String fileKey,

--- a/src/main/java/com/project/team5backend/domain/image/entity/ExhibitionImage.java
+++ b/src/main/java/com/project/team5backend/domain/image/entity/ExhibitionImage.java
@@ -1,7 +1,7 @@
 package com.project.team5backend.domain.image.entity;
 
 import com.project.team5backend.domain.exhibition.exhibition.entity.Exhibition;
-import com.project.team5backend.global.entity.BaseTimeEntity;
+import com.project.team5backend.global.entity.BaseOnlyCreateTimeEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,14 +15,14 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ExhibitionImage extends BaseTimeEntity {
+public class ExhibitionImage extends BaseOnlyCreateTimeEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "exhibition_image_id")
     private Long id;
 
     @Column(name = "image_url")
-    private String imageUrl;
+    private String fileKey;
 
     @Column(name = "is_deleted")
     private boolean isDeleted;

--- a/src/main/java/com/project/team5backend/domain/image/entity/ExhibitionImage.java
+++ b/src/main/java/com/project/team5backend/domain/image/entity/ExhibitionImage.java
@@ -34,4 +34,8 @@ public class ExhibitionImage extends BaseOnlyCreateTimeEntity {
     @JoinColumn(name = "exhibition_id")
     private Exhibition exhibition;
 
+    public void deleteImage() {
+        isDeleted = true;
+        deletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/project/team5backend/domain/image/exception/ImageErrorCode.java
+++ b/src/main/java/com/project/team5backend/domain/image/exception/ImageErrorCode.java
@@ -21,7 +21,8 @@ public enum ImageErrorCode implements BaseErrorCode {
     REDIS_SAVE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE_500_4", "Redis에 이미지 추적 정보를 저장하는 데 실패했습니다."),
     REDIS_REMOVE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE_500_5", "Redis에서 이미지 추적 정보를 제거하는 데 실패했습니다."),
     REDIS_KEY_FETCH_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE_500_6", "Redis에서 이미지 추적 키 목록을 조회하는 데 실패했습니다."),
-    REDIS_EXPIRED_FETCH_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE_500_7", "Redis에서 만료된 이미지 키를 조회하는 데 실패했습니다.")
+    REDIS_EXPIRED_FETCH_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE_500_7", "Redis에서 만료된 이미지 키를 조회하는 데 실패했습니다."),
+    S3_MOVE_TRASH_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE_500_8", "S3 파일 휴지통 이동 실패했습니다.")
     ;
 
 

--- a/src/main/java/com/project/team5backend/domain/image/exception/ImageErrorCode.java
+++ b/src/main/java/com/project/team5backend/domain/image/exception/ImageErrorCode.java
@@ -14,6 +14,7 @@ public enum ImageErrorCode implements BaseErrorCode {
     IMAGE_TOO_MANY_REQUESTS(HttpStatus.BAD_REQUEST, "IMAGE_400_4", "이미지 파일이 5개를 넘었습니다."),
     IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "IMAGE_404_1", "S3에 이미지를 찾을 수 없습니다."),
     IMAGE_INVALID_FILE_KEY(HttpStatus.NOT_FOUND, "IMAGE_400_5", "해당 유저의 fileKey가 존재하지 않습니다."),
+    IMAGE_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "IMAGE_401", "해당 fileKey에 대한 권한이 없습니다."),
     IMAGE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE_500_1", "이미지 업로드에 실패했습니다."),
     IMAGE_COMMIT_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE_500_2", "이미지 커밋에 실패했습니다."),
     IMAGE_DELETE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE_500_3", "이미지 삭제에 실패했습니다."),

--- a/src/main/java/com/project/team5backend/domain/image/repository/ExhibitionImageRepository.java
+++ b/src/main/java/com/project/team5backend/domain/image/repository/ExhibitionImageRepository.java
@@ -11,4 +11,6 @@ public interface ExhibitionImageRepository extends JpaRepository<ExhibitionImage
 
     @Query("select ei.fileKey from ExhibitionImage ei where ei.exhibition.id =:exhibitionId")
     List<String> findFileKeysByExhibitionId(@Param("exhibitionId") Long exhibitionId);
+
+    List<ExhibitionImage> findByExhibitionId(long exhibitionId);
 }

--- a/src/main/java/com/project/team5backend/domain/image/repository/ExhibitionImageRepository.java
+++ b/src/main/java/com/project/team5backend/domain/image/repository/ExhibitionImageRepository.java
@@ -2,6 +2,13 @@ package com.project.team5backend.domain.image.repository;
 
 import com.project.team5backend.domain.image.entity.ExhibitionImage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface ExhibitionImageRepository extends JpaRepository<ExhibitionImage, Long> {
+
+    @Query("select ei.fileKey from ExhibitionImage ei where ei.exhibition.id =:exhibitionId")
+    List<String> findFileKeysByExhibitionId(@Param("exhibitionId") Long exhibitionId);
 }

--- a/src/main/java/com/project/team5backend/domain/image/service/RedisImageTracker.java
+++ b/src/main/java/com/project/team5backend/domain/image/service/RedisImageTracker.java
@@ -153,19 +153,6 @@ public class RedisImageTracker {
     }
 
     /**
-     * 첫 번째 이미지 조회 (썸네일용)
-     */
-    public String getFirstImageByEmail(String email) {
-        try {
-            String zsetKey = REDIS_ZSET_KEY_PREFIX + email;
-            Set<String> firstImage = imageRedisTemplate.opsForZSet().range(zsetKey, 0, 0);
-            return firstImage.isEmpty() ? null : firstImage.iterator().next();
-        } catch (Exception e) {
-            throw new ImageException(ImageErrorCode.REDIS_KEY_FETCH_FAIL);
-        }
-    }
-
-    /**
      * 이미지 개수 조회
      */
     public long getImageCountByEmail(String email) {

--- a/src/main/java/com/project/team5backend/domain/image/service/RedisImageTracker.java
+++ b/src/main/java/com/project/team5backend/domain/image/service/RedisImageTracker.java
@@ -11,8 +11,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import lombok.extern.slf4j.Slf4j;
 
 import java.time.LocalDateTime;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 @Component
@@ -22,7 +21,6 @@ public class RedisImageTracker {
     private final RedisTemplate<String, String> imageRedisTemplate;
     private final ObjectMapper objectMapper;
 
-    // 생성자에서 @Qualifier로 imageRedisTemplate 주입
     public RedisImageTracker(
             @Qualifier("imageRedisTemplate") RedisTemplate<String, String> imageRedisTemplate,
             ObjectMapper objectMapper
@@ -31,19 +29,26 @@ public class RedisImageTracker {
         this.objectMapper = objectMapper;
     }
 
-    private static final String REDIS_KEY_PREFIX = "images:";
+    private static final String REDIS_ZSET_KEY_PREFIX = "images:ordered:";
+    private static final String REDIS_DETAIL_KEY_PREFIX = "images:detail:";
     private static final long TRACKING_DURATION_MINUTES = 30;
 
     /**
-     * Redis에 이미지 추적 정보 저장
+     * Redis ZSet에 이미지 순서와 함께 저장
      */
     public void save(String email, String fileKey) {
         try {
-            String redisKey = REDIS_KEY_PREFIX + email + ":" + fileKey;
+            // 1. ZSet에 순서 저장 (score는 현재 시간)
+            String zsetKey = REDIS_ZSET_KEY_PREFIX + email;
+            double score = System.currentTimeMillis();
+            imageRedisTemplate.opsForZSet().add(zsetKey, fileKey, score);
+            imageRedisTemplate.expire(zsetKey, TRACKING_DURATION_MINUTES, TimeUnit.MINUTES);
 
+            // 2. 상세 정보도 별도 저장 (기존 방식 유지)
+            String detailKey = REDIS_DETAIL_KEY_PREFIX + email + ":" + fileKey;
             ImageInternelDTO.ImageTrackingResDTO imageTrackingResDTO = ImageConverter.toImageTrackingResDTO(email, fileKey);
             String json = objectMapper.writeValueAsString(imageTrackingResDTO);
-            imageRedisTemplate.opsForValue().set(redisKey, json, TRACKING_DURATION_MINUTES, TimeUnit.HOURS);
+            imageRedisTemplate.opsForValue().set(detailKey, json, TRACKING_DURATION_MINUTES, TimeUnit.MINUTES);
 
         } catch (Exception e) {
             throw new ImageException(ImageErrorCode.REDIS_SAVE_FAIL);
@@ -55,55 +60,142 @@ public class RedisImageTracker {
      */
     public void remove(String email, String fileKey) {
         try {
-            String redisKey = REDIS_KEY_PREFIX + email + ":" + fileKey;
-            imageRedisTemplate.delete(redisKey);
+            // 1. ZSet에서 제거
+            String zsetKey = REDIS_ZSET_KEY_PREFIX + email;
+            imageRedisTemplate.opsForZSet().remove(zsetKey, fileKey);
+
+            // 2. 상세 정보도 제거
+            String detailKey = REDIS_DETAIL_KEY_PREFIX + email + ":" + fileKey;
+            imageRedisTemplate.delete(detailKey);
         } catch (Exception e) {
             throw new ImageException(ImageErrorCode.REDIS_REMOVE_FAIL);
         }
     }
 
     /**
-     * 모든 추적 중인 이미지 키 조회
+     * email에 맞는 이미지를 순서대로 조회 (ZSet 사용)
      */
-    public Set<String> getAllTrackedFileKeys() {
+    public List<String> getOrderedFileKeysByEmail(String email) {
         try {
-            Set<String> redisKeys = imageRedisTemplate.keys(REDIS_KEY_PREFIX + "*");
-            return redisKeys.stream()
-                    .map(key -> key.substring(REDIS_KEY_PREFIX.length()))
-                    .collect(java.util.stream.Collectors.toSet());
-
+            String zsetKey = REDIS_ZSET_KEY_PREFIX + email;
+            Set<String> orderedSet = imageRedisTemplate.opsForZSet().range(zsetKey, 0, -1);
+            return new ArrayList<>(orderedSet); // 순서 보장된 List 반환
         } catch (Exception e) {
             throw new ImageException(ImageErrorCode.REDIS_KEY_FETCH_FAIL);
         }
     }
 
     /**
-     * 특정 시간 이전의 추적 정보 조회
+     * 기존 호환성을 위한 메서드 (Set 반환)
+     */
+    @Deprecated
+    public Set<String> getTrackedFileKeysByEmail(String email) {
+        List<String> orderedList = getOrderedFileKeysByEmail(email);
+        return new LinkedHashSet<>(orderedList); // 순서 유지하는 Set으로 변환
+    }
+
+    /**
+     * 해당 유저의 모든 임시 이미지 삭제 (쓰레기 데이터 정리용)
+     */
+    public void clearUserImages(String email) {
+        try {
+            // 1. ZSet 삭제
+            String zsetKey = REDIS_ZSET_KEY_PREFIX + email;
+            imageRedisTemplate.delete(zsetKey);
+
+            // 2. 상세 정보들도 삭제
+            Set<String> detailKeys = imageRedisTemplate.keys(REDIS_DETAIL_KEY_PREFIX + email + ":*");
+            if (detailKeys != null && !detailKeys.isEmpty()) {
+                imageRedisTemplate.delete(detailKeys);
+            }
+
+            log.info("사용자 {}의 임시 이미지 모두 삭제 완료", email);
+        } catch (Exception e) {
+            throw new ImageException(ImageErrorCode.REDIS_REMOVE_FAIL);
+        }
+    }
+
+    /**
+     * 특정 시간 이전의 추적 정보 조회 (기존 방식 유지)
      */
     public Set<ImageInternelDTO.ImageTrackingResDTO> getExpiredImageEntries(LocalDateTime expiredBefore) {
-        Set<String> redisKeys = imageRedisTemplate.keys(REDIS_KEY_PREFIX + "*");
+        Set<String> detailKeys = imageRedisTemplate.keys(REDIS_DETAIL_KEY_PREFIX + "*");
         Set<ImageInternelDTO.ImageTrackingResDTO> expiredEntries = new HashSet<>();
 
-        for (String redisKey : redisKeys) {
-            try {
-                String json = imageRedisTemplate.opsForValue().get(redisKey);
-                ImageInternelDTO.ImageTrackingResDTO dto = objectMapper.readValue(json, ImageInternelDTO.ImageTrackingResDTO.class);
+        if (detailKeys == null) {
+            return expiredEntries;
+        }
 
-                if (dto.createAt().isBefore(expiredBefore)) {
-                    expiredEntries.add(dto);
+        for (String detailKey : detailKeys) {
+            try {
+                String json = imageRedisTemplate.opsForValue().get(detailKey);
+                if (json != null) {
+                    ImageInternelDTO.ImageTrackingResDTO dto = objectMapper.readValue(json, ImageInternelDTO.ImageTrackingResDTO.class);
+                    if (dto.createAt().isBefore(expiredBefore)) {
+                        expiredEntries.add(dto);
+                    }
                 }
             } catch (Exception e) {
-                log.warn("만료 여부 확인 실패: {}", redisKey, e);
+                log.warn("만료 여부 확인 실패: {}", detailKey, e);
             }
         }
 
         return expiredEntries;
     }
+
     /**
-     * fileKey의 주인 찾기
+     * fileKey의 주인 확인
      */
     public boolean isOwnedByUser(String email, String fileKey) {
-        String redisKey = REDIS_KEY_PREFIX + email + ":" + fileKey;
-        return imageRedisTemplate.hasKey(redisKey);
+        String zsetKey = REDIS_ZSET_KEY_PREFIX + email;
+        Double score = imageRedisTemplate.opsForZSet().score(zsetKey, fileKey);
+        return score != null; // score가 있으면 해당 유저 소유
+    }
+
+    /**
+     * 첫 번째 이미지 조회 (썸네일용)
+     */
+    public String getFirstImageByEmail(String email) {
+        try {
+            String zsetKey = REDIS_ZSET_KEY_PREFIX + email;
+            Set<String> firstImage = imageRedisTemplate.opsForZSet().range(zsetKey, 0, 0);
+            return firstImage.isEmpty() ? null : firstImage.iterator().next();
+        } catch (Exception e) {
+            throw new ImageException(ImageErrorCode.REDIS_KEY_FETCH_FAIL);
+        }
+    }
+
+    /**
+     * 이미지 개수 조회
+     */
+    public long getImageCountByEmail(String email) {
+        try {
+            String zsetKey = REDIS_ZSET_KEY_PREFIX + email;
+            Long count = imageRedisTemplate.opsForZSet().count(zsetKey, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY);
+            return count != null ? count : 0;
+        } catch (Exception e) {
+            throw new ImageException(ImageErrorCode.REDIS_KEY_FETCH_FAIL);
+        }
+    }
+
+    /**
+     * 디버깅용: ZSet 내용을 score와 함께 조회
+     */
+    public Map<String, Double> getImagesWithScores(String email) {
+        try {
+            String zsetKey = REDIS_ZSET_KEY_PREFIX + email;
+            Set<org.springframework.data.redis.core.ZSetOperations.TypedTuple<String>> tuples =
+                    imageRedisTemplate.opsForZSet().rangeWithScores(zsetKey, 0, -1);
+
+            Map<String, Double> result = new LinkedHashMap<>();
+            if (tuples != null) {
+                for (org.springframework.data.redis.core.ZSetOperations.TypedTuple<String> tuple : tuples) {
+                    result.put(tuple.getValue(), tuple.getScore());
+                }
+            }
+            return result;
+        } catch (Exception e) {
+            throw new ImageException(ImageErrorCode.REDIS_KEY_FETCH_FAIL);
+        }
     }
 }

--- a/src/main/java/com/project/team5backend/domain/image/service/command/ImageCommandService.java
+++ b/src/main/java/com/project/team5backend/domain/image/service/command/ImageCommandService.java
@@ -3,12 +3,14 @@ package com.project.team5backend.domain.image.service.command;
 import com.project.team5backend.domain.image.dto.request.ImageReqDTO;
 import com.project.team5backend.domain.image.dto.response.ImageResDTO;
 
+import java.util.List;
+
 public interface ImageCommandService {
     ImageResDTO.PresignedUrlResDTO generatePresignedUrl(String email, ImageReqDTO.PresignedUrlReqDTO presignedUrl);
 
-    ImageResDTO.PresignedUrlListResDTO generatePresignedUrlList(String email, ImageReqDTO.PresignedUrlListReqDTO presignedUrlListReqDTO);
-
-    String commit(String email, String fileKey);
-
     ImageResDTO.DeleteImageResDTO delete(String email, String fileKey);
+
+    void moveToTrashPrefix(List<String> keys);
+
+    void clearTrackingByEmail(String email);
 }

--- a/src/main/java/com/project/team5backend/domain/image/service/command/ImageCommandServiceImpl.java
+++ b/src/main/java/com/project/team5backend/domain/image/service/command/ImageCommandServiceImpl.java
@@ -49,6 +49,9 @@ public class ImageCommandServiceImpl implements ImageCommandService {
      */
     @Override
     public ImageResDTO.PresignedUrlResDTO generatePresignedUrl(String email, ImageReqDTO.PresignedUrlReqDTO presignedUrlReqDTO) {
+        if (redisImageTracker.getImageCountByEmail("likelion@naver.com") >= 5) {
+            throw new ImageException(ImageErrorCode.IMAGE_TOO_MANY_REQUESTS);
+        }
         return generateSinglePresignedUrl(email, presignedUrlReqDTO);
     }
 

--- a/src/main/java/com/project/team5backend/domain/image/service/command/ImageCommandServiceImpl.java
+++ b/src/main/java/com/project/team5backend/domain/image/service/command/ImageCommandServiceImpl.java
@@ -18,9 +18,11 @@ import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignReques
 import org.springframework.beans.factory.annotation.Value;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
+
 
 @Service
 @RequiredArgsConstructor
@@ -56,25 +58,6 @@ public class ImageCommandServiceImpl implements ImageCommandService {
     }
 
     /**
-     * Presigned URL 발급 , 게시글 이미지 전용
-     * @param "fileExtension" 파일 확장자 (예: jpg, png)
-     * @param "contentType" MIME 타입 (예: image/jpeg)
-     * @return Presigned URL과 파일 키
-     */
-    @Override
-    public ImageResDTO.PresignedUrlListResDTO generatePresignedUrlList(String email, ImageReqDTO.PresignedUrlListReqDTO presignedUrlListReqDTO) {
-        if (presignedUrlListReqDTO.images().size() > 5) {
-            throw new ImageException(ImageErrorCode.IMAGE_TOO_MANY_REQUESTS);
-        }
-
-        List<ImageResDTO.PresignedUrlResDTO> resDTOList = presignedUrlListReqDTO.images().stream()
-                .map(presignedUrlReqDTO -> generateSinglePresignedUrl(email, presignedUrlReqDTO))
-                .collect(Collectors.toList());
-
-        return ImageConverter.toPresignedUrlListResDTO(resDTOList);
-    }
-
-    /**
      * 단일 Presigned URL 생성 공통 메서드
      * @param email 사용자 이메일
      * @param presignedUrlReqDTO 요청 DTO
@@ -104,35 +87,8 @@ public class ImageCommandServiceImpl implements ImageCommandService {
     }
 
     /**
-     * 이미지 사용 확정 (commit)
-     */
-    @Override
-    public String commit(String email, String fileKey) {
-
-        if (fileKey == null || fileKey.trim().isEmpty()) {
-            throw new ImageException(ImageErrorCode.IMAGE_KEY_MISSING);
-        }
-
-        try {
-            // S3에 파일이 실제로 업로드되었는지 확인
-            if (!isFileExists(fileKey)) {
-                log.warn("fileKey를 찾을 수 없습니다: {}", fileKey);
-                throw new ImageException(ImageErrorCode.IMAGE_NOT_FOUND);
-            }
-
-            // Redis에서 추적 정보 제거 (더 이상 정리 대상이 아님)
-            redisImageTracker.remove(email, fileKey);
-
-            log.info("이미지가 성공적으로 저장되었습니다: {}", fileKey);
-        } catch (Exception e) {
-            throw new ImageException(ImageErrorCode.IMAGE_COMMIT_FAIL);
-        }
-        return "https://" + bucketName + ".s3." + region + ".amazonaws.com/" + fileKey;
-    }
-
-    /**
-     * 이미지 실제 삭제
-     * @param fileKey 파일 키
+     * 이미지 삭제
+     * @param fileKey 파일 키만 삭제
      */
     @Override
     public ImageResDTO.DeleteImageResDTO delete(String email, String fileKey) {
@@ -155,6 +111,67 @@ public class ImageCommandServiceImpl implements ImageCommandService {
             throw new ImageException(ImageErrorCode.IMAGE_DELETE_FAIL);
         }
         return ImageConverter.toImageDeleteResDTO(fileKey);
+    }
+    @Override
+    public void moveToTrashPrefix(List<String> fileKeys) {
+        if (fileKeys == null || fileKeys.isEmpty()) {
+            log.info("이동할 파일이 없습니다.");
+            return;
+        }
+
+        List<String> failedKeys = new ArrayList<>();
+
+        for (String src : fileKeys) {
+            try {
+                String dst = "trash/" + src; // 원래 경로 보존
+                // 1. 복사
+                CopyObjectRequest copyReq = CopyObjectRequest.builder()
+                        .sourceBucket(bucketName)
+                        .sourceKey(src)
+                        .destinationBucket(bucketName)
+                        .destinationKey(dst)
+                        .build();
+                s3Client.copyObject(copyReq);
+
+                // 2. 원본 삭제
+                DeleteObjectRequest deleteReq = DeleteObjectRequest.builder()
+                        .bucket(bucketName)
+                        .key(src)
+                        .build();
+                s3Client.deleteObject(deleteReq);
+
+                log.info("파일 휴지통 이동 완료: {} -> {}", src, dst);
+
+            } catch (Exception e) {
+                log.error("파일 휴지통 이동 실패: {}", src, e);
+                failedKeys.add(src);
+            }
+        }
+        if (!failedKeys.isEmpty()) {
+            log.warn("휴지통 이동 실패한 파일들: {}", failedKeys);
+            // 필요시 재시도 로직이나 알림 추가
+        }
+    }
+    @Override
+    public void clearTrackingByEmail(String email) {
+        List<String> fileKeys = redisImageTracker.getOrderedFileKeysByEmail(email);
+
+        try {
+            // S3에서 파일들 삭제
+            for (String fileKey : fileKeys) {
+                DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
+                        .bucket(bucketName)
+                        .key(fileKey)
+                        .build();
+                s3Client.deleteObject(deleteRequest);
+            }
+
+            // Redis에서 사용자 이미지 모두 삭제 (한 번에)
+            redisImageTracker.clearUserImages(email);
+
+        } catch (Exception e) {
+            throw new ImageException(ImageErrorCode.IMAGE_DELETE_FAIL);
+        }
     }
 
     /**

--- a/src/main/java/com/project/team5backend/domain/user/entity/User.java
+++ b/src/main/java/com/project/team5backend/domain/user/entity/User.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Table(name = "users")
 public class User extends BaseTimeEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/project/team5backend/global/entity/BaseOnlyCreateTimeEntity.java
+++ b/src/main/java/com/project/team5backend/global/entity/BaseOnlyCreateTimeEntity.java
@@ -1,0 +1,19 @@
+package com.project.team5backend.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+public class BaseOnlyCreateTimeEntity {
+    @CreatedDate
+    @Column(name = "created_at")
+    private LocalDateTime createAt;
+}


### PR DESCRIPTION
# ☝️Issue Number

- #5 
- #8 

##  📌 개요

- 좋아요 생성 취소 api 구현
-  전시 CRD api에 이미지 로직 적용
-  전시 생성 전에 한번 쓰레기 이미지 fileKey 정리 api 구현 (전시, 리뷰 공간 등록 페이지 들어가기전 무조건 실행해야함!!)
-  좋아요를 제외한 전시, 리뷰, 이미지는 db에 softdelete 설정
-  좋아요와 쓰레기값인 이미지 fileKey는 삭제 시, redis와 s3, db에 하드 딜리트 되도록 설정
-  소프트 딜리트 된 이미지는 s3에서 기존 image에서  trash/image 로 옮겨져서 소프트 딜리트 처리함 

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
